### PR TITLE
Parameterize query to prevent SQL injection

### DIFF
--- a/whatportis/main.py
+++ b/whatportis/main.py
@@ -41,10 +41,9 @@ def get_ports(port, like=False):
     cursor = conn.cursor()
 
     where_field = "port" if isinstance(port, int) else "name"
-    where_value = " LIKE '%{}%'".format(port) if like else "='{}'".format(port)
+    where_value = "%{}%".format(port) if like else port
 
-    sql = BASE_SQL + where_field + where_value
-    cursor.execute(sql)
+    cursor.execute(BASE_SQL + where_field + " LIKE ?", (where_value,))
 
     return cursor
 


### PR DESCRIPTION
howdy! I just ran across this tool on the twitters and it's *pretty sweet*

But I also noticed that `whatportis "hello' OR 1 = 1;--hello"` dumps the whole database.

It's not a huge problem, but it's easily fixed, so I fixed it :) This was literally a 5 minute hackjob (mostly trying to test that my fix fixed it), so do with it what you will. As far as I can tell, this changes no behavior otherwise.

Edit: In another world I'd prefer no dynamically constructed queries, but I figure this is a pretty minimal change, so easy to review!