### PR TITLE
Make useable as module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 entry_points = {
     'console_scripts': [
-        'whatportis=whatportis.main:run',
+        'whatportis=whatportis.__main__:run',
     ]
 }
 requirements = open('requirements.txt').read()

--- a/test_whatportis.py
+++ b/test_whatportis.py
@@ -3,7 +3,7 @@ import re
 
 import click
 from click.testing import CliRunner
-from whatportis.main import run
+from whatportis.__main__ import run
 
 
 class WhatportisTestCase(unittest.TestCase):

--- a/whatportis/__init__.py
+++ b/whatportis/__init__.py
@@ -1,1 +1,5 @@
-from whatportis.main import get_ports
+# -*- coding: utf-8 -*-
+
+from .core import get_ports
+
+__all__ = ["get_ports"]

--- a/whatportis/__main__.py
+++ b/whatportis/__main__.py
@@ -1,13 +1,13 @@
-import os
-import sqlite3
+# -*- coding: utf-8 -*-
+
+"""
+    command line interface for whatportis application.
+"""
 
 import click
 from prettytable import PrettyTable
 
-
-BASE_PATH = os.path.dirname(os.path.abspath(__file__))
-DATABASE_PATH = os.path.join(BASE_PATH, 'ports.db')
-BASE_SQL = "SELECT name, port, protocol, description FROM ports WHERE "
+from .core import get_ports
 
 
 def valid_port(ctx, param, value):
@@ -28,26 +28,6 @@ def valid_port(ctx, param, value):
     return value
 
 
-def get_ports(port, like=False):
-    """
-    This function creates the SQL query depending on the specified port and
-    the --like option.
-
-    :param port: the specified port
-    :param like: the --like option
-    :return: the sqlite3 cursor
-    """
-    conn = sqlite3.connect(DATABASE_PATH)
-    cursor = conn.cursor()
-
-    where_field = "port" if isinstance(port, int) else "name"
-    where_value = "%{}%".format(port) if like else port
-
-    cursor.execute(BASE_SQL + where_field + " LIKE ?", (where_value,))
-
-    return cursor
-
-
 def get_table(ports):
     """
     This function returns a pretty table used to display the port results.
@@ -60,8 +40,8 @@ def get_table(ports):
     table.align["Description"] = "l"
     table.padding_width = 1
 
-    for p in ports:
-        table.add_row(p)
+    for port in ports:
+        table.add_row(port)
 
     return table
 

--- a/whatportis/core.py
+++ b/whatportis/core.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+"""
+    Provides functionality to search a port
+    database for specific applications and
+    their ports.
+"""
+
+import os
+import sqlite3
+from collections import namedtuple
+
+__BASE_PATH__ = os.path.dirname(os.path.abspath(__file__))
+__DATABASE_PATH__ = os.path.join(__BASE_PATH__, 'ports.db')
+__BASE_SQL__ = "SELECT name, port, protocol, description FROM ports WHERE "
+
+Port = namedtuple("Port", ["name", "port", "protocol", "description"])
+
+
+def get_ports(port, like=False):
+    """
+    This function creates the SQL query depending on the specified port and
+    the --like option.
+
+    :param port: the specified port
+    :param like: the --like option
+    :return: all ports matching the given ``port``
+    :rtype: list
+    """
+    conn = sqlite3.connect(__DATABASE_PATH__)
+    cursor = conn.cursor()
+
+    where_field = "port" if isinstance(port, int) else "name"
+    where_value = "%{}%".format(port) if like else port
+
+    cursor.execute(__BASE_SQL__ + where_field + " LIKE ?", (where_value,))
+    return [Port(*row) for row in cursor]


### PR DESCRIPTION
Split main module into two modules:
- core
- \_\_main\_\_

The core module provides the functionality to search for a port in the database
The \_\_main\_\_ file is used for the CLI

```
>>> from whatportis import get_ports
>>> get_ports("mysql")
[Port(name=mysql, port=3306, protocol=tcp, description=MySQL), Port(name=mysql, port=3306, protocol=udp, description=MySQL)]
>>>
```